### PR TITLE
add custom fields to user profile

### DIFF
--- a/templates/account/profile.tpl
+++ b/templates/account/profile.tpl
@@ -82,6 +82,8 @@
 			<span>[[user:age]]</span>
 			<strong>{age}</strong>
 			<!-- ENDIF age -->
+
+                        <!-- IMPORT partials/account/custom_fields_flex.tpl -->
 		</div>
 	</div>
 


### PR DESCRIPTION
Simple tweak to show custom fields in user profile. It can be used later for a map because this data is also showing in api request.
Signed-off-by: Gerard Kowalski <zgderek92@gmail.com>